### PR TITLE
Further optimize ensure annotations

### DIFF
--- a/ensure/__init__.py
+++ b/ensure/__init__.py
@@ -653,25 +653,23 @@ def ensure_annotations(f):
                     if not isinstance(value, templ):
                         msg = "Default argument {arg} to {f} does not match annotation type {t}"
                         raise EnsureError(msg.format(arg=arg, f=f, t=templ))
-    arg_pos = {arg: pos for pos, arg in enumerate(f.__code__.co_varnames)}
+    arg_properties = []
+    for pos, arg in enumerate(f.__code__.co_varnames):
+        if arg in f.__annotations__:
+            templ = f.__annotations__[arg]
+            arg_properties.append((arg, templ, pos))
     from functools import wraps
 
     @wraps(f)
     def wrapper(*args, **kwargs):
-        for arg, templ in f.__annotations__.items():
-            if arg == 'return':
-                continue
+        for arg, templ, pos in arg_properties:
+            if len(args) > pos:
+                value = args[pos]
             elif arg in kwargs:
                 value = kwargs[arg]
             else:
-                if arg in arg_pos:
-                    pos = arg_pos[arg]
-                    if len(args) > pos:
-                        value = args[pos]
-                    else:
-                        continue
-                else:
-                    continue
+                continue
+
             if not isinstance(value, templ):
                 msg = "Argument {arg} to {f} does not match annotation type {t}"
                 raise EnsureError(msg.format(arg=arg, f=f, t=templ))


### PR DESCRIPTION
The wrapper can be further optimized. This new change stores each arg name, template, and position together. This eliminates the 'return' map lookup each iteration, avoids the kwargs map lookup check if it was positional, and eliminates the arg to pos map lookup as well.

Microbenchmark:

Before:
Mean 3.297391904052347 us
Min 2.9989751055836678 us
Max 31.033996492624283 us
stdev 5.870001651992793e-07

After:
Mean 2.516213699709624 us
Min 2.249958924949169 us
Max 21.4350875467062 us
stdev 5.480925631868802e-07

Unit tests pass, as well as a program using this. I believe this works (and I think it simplifies the logic too), will think about it more, but pretty sure this should do it.
