### PR TITLE
Only look at variables that are arguments in the function

### DIFF
--- a/ensure/__init__.py
+++ b/ensure/__init__.py
@@ -658,6 +658,8 @@ def ensure_annotations(f):
         if arg in f.__annotations__:
             templ = f.__annotations__[arg]
             arg_properties.append((arg, templ, pos))
+        elif pos >= f.__code__.co_argcount:
+            break
     from functools import wraps
 
     @wraps(f)

--- a/test/test.py
+++ b/test/test.py
@@ -142,11 +142,14 @@ global f, g
 
 @ensure_annotations
 def f(x: int, y: float) -> float:
-    return x+y if x+y > 0 else int(x+y)
+    t = x+y
+    r = t > 0
+    return t if r else int(t)
 
 @ensure_annotations
 def g(x: str, y: str="default") -> str:
-    return x+y
+    t = x+y
+    return t
 """
         exec(f_code)
         self.assertEqual(f(1, 2.3), 3.3)


### PR DESCRIPTION
f.**code**.co_varnames are ALL the variables in a function (not just the ones which are arguments). Those are the first ones in up to co_argcount so stop loping after it. (Of course, it won't be in the **annotations**, but if there is a long function it's a waste of time to check these variables as the decorator is being applied).
